### PR TITLE
hyw/feat/logout&blockloginpage

### DIFF
--- a/src/pages/admin/logout.tsx
+++ b/src/pages/admin/logout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Logout from '../components/admin/Logout';
+
+const LoginPage = () => {
+    return (
+        <div>
+            <Logout />
+        </div>
+    );
+};
+
+export default LoginPage;

--- a/src/pages/components/admin/LoginForm.tsx
+++ b/src/pages/components/admin/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useRouter } from 'next/router';
 
@@ -7,6 +7,15 @@ const LoginForm = () => {
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
     const router = useRouter();
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (token) {
+            // 토큰이 있으면 이전 페이지로 리디렉션
+            router.push('/admin/logout');
+            //router.back(); 만약 지금 로그아웃이 저 페이지 말고  다른 곳에 구현이 되어있다면 위에 코드를 지우고, 이 함수를 사용해주세요.
+        }
+    }, [router]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/src/pages/components/admin/Logout.tsx
+++ b/src/pages/components/admin/Logout.tsx
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+
+const Logout = () => {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
+    const router = useRouter();
+
+    // useEffect(() => {
+    //     const token = localStorage.getItem('token');
+    //     if (token) {
+    //         // 토큰이 있으면 이전 페이지로 리디렉션
+    //         router.back();
+    //     }
+    // }, [router]);
+
+    const handleLogout = () => {
+        localStorage.removeItem('token');
+    };
+
+    return (
+        <div className="min-h-screen bg-orange-50 flex justify-center items-center">
+            <form  className="pt-28 pb-40 px-16 bg-white rounded-2xl shadow-xl z-20">
+                <button onClick={handleLogout} type="button" className="block  font-bold text-white bg-orange-400 text-sm py-2 px-4 my-3 rounded-lg w-full border outline-gray-500">로그아웃</button>
+            </form>
+        </div>
+    );
+};
+
+export default Logout;


### PR DESCRIPTION
fix #118 
fix #119 

로컬 스토리지에 토큰의 존재 여부를 판단하여 문제를 만약 로그인이 되어있을 경우 지금은 로그 아웃 페이지로 넘어가게 제작하였습니다.
또한 해당 페이지에서 버튼을 누르면 토큰을 초기화하여 로그아웃이 가능하게 제작하였습니다.
로그아웃이 되면, 다시 로그인페이지에 접근할 수 있습니다.
추후에 로그아웃 기능이 다른페이지에서 구현이 된다면(헤더 등), 라우팅을 로그아웃 페이지가 아닌 바로 이전페이지가 되도록 수정이 용이하게 해두었습니다.